### PR TITLE
Add light red border to card components

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-lg border border-red-200 bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -89,7 +89,7 @@
   
   /* ITSAR-style card */
   .its-card {
-    @apply bg-its-card rounded-its shadow-its-card;
+    @apply bg-its-card rounded-its shadow-its-card border border-red-200;
   }
 }
 


### PR DESCRIPTION
## Summary
- style cards with a subtle red border
- ensure Card UI component uses red border by default

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68aed2bd9f188331bbd03d802164b16a